### PR TITLE
goalsテーブルとの関連付けを修正

### DIFF
--- a/app/controllers/goals_controller.rb
+++ b/app/controllers/goals_controller.rb
@@ -1,6 +1,6 @@
 class GoalsController < ApplicationController
   before_action :correct_user, only: [:edit, :update, :destroy]
-  
+
   def index
     @goals = current_user.goals.order(id: :desc).page(params[:page]).per(5)
   end

--- a/app/models/bad_habit.rb
+++ b/app/models/bad_habit.rb
@@ -1,6 +1,6 @@
 class BadHabit < ApplicationRecord
   belongs_to :goal
-  has_many :bad_logs
+  has_many :bad_logs, dependent: :destroy
   
   validates :name, presence: true, length: { maximum: 100 }
 end

--- a/app/models/goal.rb
+++ b/app/models/goal.rb
@@ -1,7 +1,7 @@
 class Goal < ApplicationRecord
   belongs_to :user
-  has_many :good_habits
-  has_many :bad_habits
+  has_many :good_habits, dependent: :destroy
+  has_many :bad_habits, dependent: :destroy
   
   validates :name, presence: true, length: { maximum: 100 }
 end

--- a/app/models/good_habit.rb
+++ b/app/models/good_habit.rb
@@ -1,6 +1,6 @@
 class GoodHabit < ApplicationRecord
   belongs_to :goal
-  has_many :good_logs
+  has_many :good_logs, dependent: :destroy
   
   validates :name, presence: true, length: { maximum: 100 }
 end


### PR DESCRIPTION
why
goalsテーブルのインスタンスを削除可能にするため。

what
dependent: :destroyをgoals,good_habit,bad_habit各modelに追記。