### PR TITLE
log機能メソッドを修正

### DIFF
--- a/app/helpers/logs_helper.rb
+++ b/app/helpers/logs_helper.rb
@@ -65,7 +65,7 @@ module LogsHelper
         if record != 0
           record
         end
-      else
+      elsif days(habit) != 1
         days(habit)
       end
     end


### PR DESCRIPTION
why
意図しないが見られたため
１日なのに「連続１日」と表示されていた

what
logs.helperを修正