### PR TITLE
ローカル環境にクローン、開発環境を整えた #23

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -242,4 +242,4 @@ RUBY VERSION
    ruby 2.5.3p105
 
 BUNDLED WITH
-   1.17.3
+   2.1.4

--- a/config/database.yml
+++ b/config/database.yml
@@ -15,7 +15,7 @@ default: &default
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: root
   password:
-  socket: /var/lib/mysql/mysql.sock
+  socket: /tmp/mysql.sock
 
 development:
   <<: *default


### PR DESCRIPTION
why
AWS cloud9から、ローカル環境vscodeでの開発に切り替えるため。

what
gemfile sql 関連を変更。